### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ appDisplayName = Disqus
 vendorName = Enonic USA
 vendorUrl = https://enonic.com
 xpVersion=8.0.0-B4
-version=1.5.0-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bumps `version` in `gradle.properties` from `1.5.0-SNAPSHOT` to `2.0.0-SNAPSHOT` (next-major) so master can take XP 8 changes without conflicting with the XP 7 line.
- Branches the XP 7 maintenance line at [`1.x`](https://github.com/enonic/app-disqus/tree/1.x), pinned to commit `ed1bc0b` (the post-`v1.4.0` "Updated to next SNAPSHOT version" commit, so it stays at `1.5.0-SNAPSHOT`).
- Adds a `releaseBranch:` block to the build-and-publish workflow listing both `master` and `1.x`, so the release-tools action treats pushes to either branch as release-eligible.

A companion PR against `1.x` adds the same `releaseBranch:` block on that branch (required so pushes to `1.x` are recognized as release-branch builds — the action reads `releaseBranch:` from each branch's own workflow file).

Reference: app-booster's master/1.x split.

## Test plan

- [ ] CI green on this PR (`enonic/release-tools/build-and-publish@master`)
- [ ] After merge: `./gradlew clean build` from master is green
- [ ] After companion `1.x` PR merges: a CI run on `1.x` classifies it as a release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)