### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,0 +1,29 @@
+name: Gradle Build
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
+    steps:
+      - uses: enonic/release-tools/release@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/enonic-gradle.yml` to the `1.x` maintenance branch with a `releaseBranch:` block listing both `master` and `1.x`. The source SHA the branch was cut from (`ed1bc0b`) predates the modern `enonic/release-tools/build-and-publish@master` workflow, so the file is created (not edited) here, mirroring the post-merge content of the companion master PR.
- Required so CI runs on `1.x` are classified as release-branch builds — the release-tools action reads `releaseBranch:` from each branch's own workflow file, so master alone is not enough.
- Per app-booster's reference, only the workflow change goes on `1.x`. No version bump, no other Step-2 changes.

Companion: [PR #37 against `master`](https://github.com/enonic/app-disqus/pull/37) — version bump and the same workflow edit.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: a CI run on `1.x` classifies it as a release branch
- [ ] `gradle.properties` on `1.x` stays at `1.5.0-SNAPSHOT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)