### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     include xplibs.portal
-    include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
+    include libs.lib.thymeleaf
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+thymeleaf = "3.0.0-SNAPSHOT"
+
+[libraries]
+lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Move the one inline dependency version into a Gradle version catalog so version pinning across the IdeaProjects tree lives in one consistent place (`gradle/libs.versions.toml`).

This is a pin-for-pin migration — no versions bumped.

## Changes

- New file `gradle/libs.versions.toml` (catalog content below).
- `build.gradle`: `include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"` → `include libs.lib.thymeleaf`.

`xpVersion` left in `gradle.properties` — the rest of the toolchain expects it there.
`xplibs.*` accessors untouched (they come from the XP gradle plugin, not the per-repo catalog).

## Conventions adopted

- Alphabetical sort of `[versions]` and `[libraries]`.
- Hyphen-separated keys (`thymeleaf`, `lib-thymeleaf`) — matches `app-facebook-pixel`, `app-rss`, `app-siteimprove`.
- `lib-<name>` library keys.

## Catalog

```toml
[versions]
thymeleaf = "3.0.0-SNAPSHOT"

[libraries]
lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
```

## Verification

- `./gradlew clean build --refresh-dependencies` — green.
- `./gradlew dependencies --configuration runtimeClasspath` — tree identical to pre-migration HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)